### PR TITLE
[FIX] initial index in migration fail

### DIFF
--- a/src/main/org/atriasoft/archidata/migration/MigrationEngine.java
+++ b/src/main/org/atriasoft/archidata/migration/MigrationEngine.java
@@ -259,7 +259,6 @@ public class MigrationEngine {
 					// we insert a placeholder to simulate the last migration is well done.
 					final String placeholderName = this.datas.get(this.datas.size() - 1).getName();
 					Migration migrationResult = new Migration();
-					migrationResult.id = 1000L;
 					migrationResult.name = placeholderName;
 					migrationResult.stepId = 0;
 					migrationResult.terminated = true;


### PR DESCRIPTION
when initialization the first migration the initail ID fail to set (forbidden case) ==> remove it