### PR TITLE
[FIX] object enum key on map generation should not be mandatory

### DIFF
--- a/src/main/org/atriasoft/archidata/externalRestApi/typescript/TsClassElement.java
+++ b/src/main/org/atriasoft/archidata/externalRestApi/typescript/TsClassElement.java
@@ -641,8 +641,12 @@ public class TsClassElement {
 			final TsClassElementGroup tsGroup,
 			final ImportModel imports) {
 		final StringBuilder out = new StringBuilder();
-		boolean enumKey = false;
-		out.append("zod.record(");
+		// Use partialRecord for enum keys to avoid Zod v4 exhaustive key check (Java Map semantics = partial keys)
+		if (model.keyModel instanceof ClassEnumModel) {
+			out.append("zod.partialRecord(");
+		} else {
+			out.append("zod.record(");
+		}
 		if (model.keyModel instanceof final ClassListModel fieldListModel) {
 			final String tmp = generateTsList(fieldListModel, tsGroup, imports);
 			out.append(tmp);
@@ -655,7 +659,6 @@ public class TsClassElement {
 		} else if (model.keyModel instanceof final ClassEnumModel fieldEnumModel) {
 			final String tmp = generateTsEnum(fieldEnumModel, tsGroup, imports);
 			out.append(tmp);
-			enumKey = true;
 		}
 		out.append(", ");
 		if (model.valueModel instanceof final ClassListModel fieldListModel) {
@@ -672,9 +675,6 @@ public class TsClassElement {
 			out.append(tmp);
 		}
 		out.append(")");
-		if (enumKey) {
-			out.append(".partial()");
-		}
 		return out.toString();
 	}
 


### PR DESCRIPTION
Problème

  En Zod v4, z.record(z.enum([...]), z.string()) effectue une vérification
  exhaustive des clés : toutes les valeurs de l'enum doivent être présentes comme
  clés dans l'objet parsé. C'est un breaking change par rapport à Zod v3 où les
  clés étaient optionnelles.

  Ce comportement est incompatible avec la sémantique Java de Map<Enum, V>, où seul
   un sous-ensemble des clés enum peut être présent.

  Le fix précédent (.partial() chaîné après zod.record()) n'est pas la bonne
  approche : .partial() rend les valeurs optionnelles (undefined accepté), mais ne
  désactive pas nécessairement la vérification d'exhaustivité des clés.

  Correctif

  Remplacer zod.record(ZodEnum, value).partial() par zod.partialRecord(ZodEnum,
  value).

  z.partialRecord() est l'API dédiée introduite en Zod v4 qui désactive la
  vérification exhaustive des clés tout en conservant la validation des valeurs.
  C'est la solution recommandée par le mainteneur de Zod et le guide de migration
  officiel.

  Les Map avec des clés non-enum (String, Integer, ObjectId...) ne sont pas
  impactées et continuent d'utiliser zod.record().

  Sources

  - https://zod.dev/v4/changelog — documente le changement de comportement de
  z.record() et recommande z.partialRecord()
  - https://github.com/colinhacks/zod/issues/4571 — confirmation par le mainteneur
  que c'était une "unsoundness in Zod 3 that is now fixed", avec z.partialRecord()
  comme migration path
  - https://zod.dev/api — documentation de z.partialRecord() qui "skips the special
   exhaustiveness checks Zod normally runs with z.enum() and z.literal() key
  schemas"