### PR TITLE
[FIX] typescript generic container values are nullable by default

### DIFF
--- a/src/main/org/atriasoft/archidata/externalRestApi/model/ClassListModel.java
+++ b/src/main/org/atriasoft/archidata/externalRestApi/model/ClassListModel.java
@@ -1,6 +1,7 @@
 package org.atriasoft.archidata.externalRestApi.model;
 
 import java.io.IOException;
+import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Set;
@@ -13,6 +14,11 @@ import java.util.Set;
 public class ClassListModel extends ClassModel {
 	/** The class model for the list element type. */
 	public ClassModel valueModel;
+	/**
+	 * Whether the list element may be {@code null}. Defaults to {@code true} (Java lists may
+	 * contain {@code null} values); a type-use {@code @NotNull} on the element forces it false.
+	 */
+	public boolean valueNullable = true;
 
 	/**
 	 * Constructs a list model from a pre-resolved element model.
@@ -20,6 +26,18 @@ public class ClassListModel extends ClassModel {
 	 */
 	public ClassListModel(final ClassModel valueModel) {
 		this.valueModel = valueModel;
+	}
+
+	/**
+	 * Constructs a list model from the annotated element type, capturing the element's type-use
+	 * nullability (e.g. {@code List<@NotNull Integer>}).
+	 * @param annotatedValue the annotated element type
+	 * @param previousModel the model group for resolving types
+	 * @throws IOException if type resolution fails
+	 */
+	public ClassListModel(final AnnotatedType annotatedValue, final ModelGroup previousModel) throws IOException {
+		this.valueModel = getModel(annotatedValue, previousModel);
+		this.valueNullable = !isTypeArgumentNotNull(annotatedValue);
 	}
 
 	/**

--- a/src/main/org/atriasoft/archidata/externalRestApi/model/ClassMapModel.java
+++ b/src/main/org/atriasoft/archidata/externalRestApi/model/ClassMapModel.java
@@ -1,6 +1,7 @@
 package org.atriasoft.archidata.externalRestApi.model;
 
 import java.io.IOException;
+import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.HashSet;
@@ -16,6 +17,12 @@ public class ClassMapModel extends ClassModel {
 	public ClassModel keyModel;
 	/** The class model for the map value type. */
 	public ClassModel valueModel;
+	/**
+	 * Whether the map value may be {@code null}. Defaults to {@code true} (Java maps may hold
+	 * {@code null} values); a type-use {@code @NotNull} on the value forces it false. The key is
+	 * never nullable (a record key can not be {@code null}).
+	 */
+	public boolean valueNullable = true;
 
 	/**
 	 * Constructs a map model from pre-resolved key and value models.
@@ -25,6 +32,21 @@ public class ClassMapModel extends ClassModel {
 	public ClassMapModel(final ClassModel keyModel, final ClassModel valueModel) {
 		this.keyModel = keyModel;
 		this.valueModel = valueModel;
+	}
+
+	/**
+	 * Constructs a map model from the annotated key and value types, capturing the value's type-use
+	 * nullability (e.g. {@code Map<String, @NotNull List<Integer>>}). The key is never nullable.
+	 * @param annotatedKey the annotated key type
+	 * @param annotatedValue the annotated value type
+	 * @param previousModel the model group for resolving types
+	 * @throws IOException if type resolution fails
+	 */
+	public ClassMapModel(final AnnotatedType annotatedKey, final AnnotatedType annotatedValue,
+			final ModelGroup previousModel) throws IOException {
+		this.keyModel = getModel(annotatedKey, previousModel);
+		this.valueModel = getModel(annotatedValue, previousModel);
+		this.valueNullable = !isTypeArgumentNotNull(annotatedValue);
 	}
 
 	/**

--- a/src/main/org/atriasoft/archidata/externalRestApi/model/ClassModel.java
+++ b/src/main/org/atriasoft/archidata/externalRestApi/model/ClassModel.java
@@ -1,6 +1,8 @@
 package org.atriasoft.archidata.externalRestApi.model;
 
 import java.io.IOException;
+import java.lang.reflect.AnnotatedParameterizedType;
+import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.HashSet;
@@ -12,6 +14,8 @@ import org.atriasoft.archidata.annotation.apiGenerator.ApiGenerationMode;
 import org.atriasoft.archidata.tools.AnnotationCreator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import jakarta.validation.constraints.NotNull;
 
 /**
  * Abstract base class representing a data model extracted from a Java class for API generation.
@@ -89,6 +93,71 @@ public abstract class ClassModel {
 			throw new IOException("Fail to manage parametrized type... '" + rawType + "'");
 		}
 		return previousModel.add((Class<?>) type);
+	}
+
+	/**
+	 * Resolves a {@link ClassModel} for the given type, preferring the annotated type when it
+	 * carries type-use information for a generic container (List/Map), otherwise falling back to
+	 * the resolved (generic-variable aware) type.
+	 *
+	 * <p>The annotated path is only taken for {@code List}/{@code Map} parameterized types so that
+	 * type-use nullability annotations (e.g. {@code List<@NotNull Integer>}) are captured, while
+	 * every other case keeps the well-tested {@link #getModel(Type, ModelGroup)} resolution.
+	 * @param annotatedType the annotated type of the property, or {@code null} if unavailable
+	 * @param fallbackType the resolved generic type to use when the annotated type is not usable
+	 * @param previousModel the model group for looking up or creating models
+	 * @return the resolved class model
+	 * @throws IOException if the type cannot be resolved
+	 */
+	public static ClassModel getModel(
+			final AnnotatedType annotatedType,
+			final Type fallbackType,
+			final ModelGroup previousModel) throws IOException {
+		if (annotatedType instanceof AnnotatedParameterizedType
+				&& annotatedType.getType() instanceof final ParameterizedType paramType
+				&& paramType.getRawType() instanceof final Class<?> rawClass
+				&& (List.class.isAssignableFrom(rawClass) || Map.class.isAssignableFrom(rawClass))) {
+			return getModel(annotatedType, previousModel);
+		}
+		return getModel(fallbackType, previousModel);
+	}
+
+	/**
+	 * Resolves a {@link ClassModel} for the given annotated type, handling parameterized types
+	 * (List, Map) and propagating type-use nullability of their arguments.
+	 * @param annotatedType the annotated Java type to resolve
+	 * @param previousModel the model group for looking up or creating models
+	 * @return the resolved class model
+	 * @throws IOException if the type cannot be resolved
+	 */
+	public static ClassModel getModel(final AnnotatedType annotatedType, final ModelGroup previousModel)
+			throws IOException {
+		if (annotatedType instanceof final AnnotatedParameterizedType annotatedParamType
+				&& annotatedType.getType() instanceof final ParameterizedType paramType
+				&& paramType.getRawType() instanceof final Class<?> rawClass) {
+			final AnnotatedType[] annotatedArguments = annotatedParamType.getAnnotatedActualTypeArguments();
+			if (List.class.isAssignableFrom(rawClass)) {
+				return new ClassListModel(annotatedArguments[0], previousModel);
+			}
+			if (Map.class.isAssignableFrom(rawClass)) {
+				return new ClassMapModel(annotatedArguments[0], annotatedArguments[1], previousModel);
+			}
+			throw new IOException("Fail to manage parametrized type... '" + rawClass + "'");
+		}
+		return previousModel.add((Class<?>) annotatedType.getType());
+	}
+
+	/**
+	 * Determines whether a generic type argument is explicitly marked as non-null via a type-use
+	 * {@code @NotNull} annotation (e.g. the {@code Integer} in {@code List<@NotNull Integer>}).
+	 *
+	 * <p>By default a generic container value is considered nullable (Java collections may contain
+	 * {@code null} values); a type-use {@code @NotNull} forces it to be non-null.
+	 * @param annotatedType the annotated type argument to inspect
+	 * @return {@code true} if the argument carries a type-use {@code @NotNull} annotation
+	 */
+	public static boolean isTypeArgumentNotNull(final AnnotatedType annotatedType) {
+		return annotatedType.getAnnotation(NotNull.class) != null;
 	}
 
 	/**

--- a/src/main/org/atriasoft/archidata/externalRestApi/model/ClassObjectModel.java
+++ b/src/main/org/atriasoft/archidata/externalRestApi/model/ClassObjectModel.java
@@ -1,6 +1,7 @@
 package org.atriasoft.archidata.externalRestApi.model;
 
 import java.io.IOException;
+import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.Field;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -286,6 +287,22 @@ public class ClassObjectModel extends ClassModel {
 		}
 
 		/**
+		 * Returns the annotated type of the property (from its backing field, or its getter as a
+		 * fallback). Used to read type-use annotations on generic arguments (e.g. nullability).
+		 * @param property the bean property descriptor
+		 * @return the annotated type, or {@code null} if neither a field nor a getter is available
+		 */
+		private static AnnotatedType getAnnotatedType(final PropertyDescriptor property) {
+			if (property.getField() != null) {
+				return property.getField().getAnnotatedType();
+			}
+			if (property.getGetter() != null) {
+				return property.getGetter().getAnnotatedReturnType();
+			}
+			return null;
+		}
+
+		/**
 		 * Constructs a FieldProperty from a bean PropertyDescriptor (supports POJO, Record, Bean).
 		 * @param property the bean property descriptor
 		 * @param previous the model group for resolving referenced types
@@ -295,7 +312,7 @@ public class ClassObjectModel extends ClassModel {
 		public FieldProperty(final PropertyDescriptor property, final ModelGroup previous)
 				throws DataAccessException, IOException {
 			this(property.getName(), //
-					ClassModel.getModel(property.getTypeInfo().genericType(), previous), //
+					ClassModel.getModel(getAnnotatedType(property), property.getTypeInfo().genericType(), previous), //
 					getSubModelIfExist(property, previous), //
 					property.getAnnotation(CheckForeignKey.class), //
 					getSchemaDescription(property), //

--- a/src/main/org/atriasoft/archidata/externalRestApi/typescript/TsClassElement.java
+++ b/src/main/org/atriasoft/archidata/externalRestApi/typescript/TsClassElement.java
@@ -867,6 +867,10 @@ public class TsClassElement {
 			final String tmp = generateTsEnum(fieldEnumModel, tsGroup, imports);
 			out.append(tmp);
 		}
+		// A Map value may be null by default (Java semantics); a type-use @NotNull forces it non-null.
+		if (model.valueNullable) {
+			out.append(".nullable()");
+		}
 		out.append(")");
 		return out.toString();
 	}
@@ -912,6 +916,10 @@ public class TsClassElement {
 		} else if (model.valueModel instanceof final ClassEnumModel fieldEnumModel) {
 			final String tmp = generateTsEnum(fieldEnumModel, tsGroup, imports);
 			out.append(tmp);
+		}
+		// A List element may be null by default (Java semantics); a type-use @NotNull forces it non-null.
+		if (model.valueNullable) {
+			out.append(".nullable()");
 		}
 		out.append(")");
 		return out.toString();

--- a/src/test/test/atriasoft/archidata/externalRestApi/TestTypeScriptApiGeneration.java
+++ b/src/test/test/atriasoft/archidata/externalRestApi/TestTypeScriptApiGeneration.java
@@ -157,6 +157,61 @@ public class TestTypeScriptApiGeneration {
 		}
 	}
 
+	// -- Nested generic nullability test model --
+	// Checks that the *value* of a generic container (List element, Map value) is nullable by
+	// default and can be forced non-null with a type-use @NotNull annotation. The Map key stays
+	// non-null (a record key can not be null).
+	public static class TestGenericNullableObject {
+		// List element nullable by default + field nullable by default.
+		public List<Integer> listDefault;
+		// List element forced non-null with type-use @NotNull + field non-null with @NotNull.
+		@NotNull
+		public List<@NotNull Integer> listNotNull;
+		// Map value (List) and its element (Integer) nullable by default + field nullable.
+		public Map<String, List<Integer>> mapListDefault;
+		// Field forced non-null, but inner List value and Integer element stay nullable by default.
+		@NotNull
+		public Map<String, List<Integer>> mapListNotNullField;
+		// Everything forced non-null with type-use @NotNull (except the Map key, never nullable).
+		@NotNull
+		public Map<String, @NotNull List<@NotNull Integer>> mapListAllNotNull;
+	}
+
+	@Path("genericNullablePath")
+	public class SampleResourceGenericNullableGet {
+		@GET
+		@Path("{oid}")
+		public TestGenericNullableObject get(@PathParam("oid") final ObjectId oid) {
+			return null;
+		}
+	}
+
+	// -- Deep / independent generic nullability test model --
+	// Checks that a type-use @NotNull applies independently at each nesting level, and that nested
+	// same-kind containers (List of List) recurse correctly.
+	public static class TestGenericNullableDeepObject {
+		// Only the Map value (the List) is forced non-null; the inner Integer stays nullable.
+		@NotNull
+		public Map<String, @NotNull List<Integer>> mapValueNotNull;
+		// Only the inner Integer is forced non-null; the Map value (the List) stays nullable.
+		@NotNull
+		public Map<String, List<@NotNull Integer>> mapElementNotNull;
+		// Nested list of list: both levels nullable by default + field nullable by default.
+		public List<List<Integer>> listOfList;
+		// Nested list of list with only the innermost Integer forced non-null.
+		@NotNull
+		public List<List<@NotNull Integer>> listOfListElementNotNull;
+	}
+
+	@Path("genericNullableDeepPath")
+	public class SampleResourceGenericNullableDeepGet {
+		@GET
+		@Path("{oid}")
+		public TestGenericNullableDeepObject get(@PathParam("oid") final ObjectId oid) {
+			return null;
+		}
+	}
+
 	// -- @JsonInclude(NON_NULL) test models --
 
 	@JsonInclude(JsonInclude.Include.NON_NULL)
@@ -1038,5 +1093,86 @@ public class TestTypeScriptApiGeneration {
 					}
 				}
 				""", generation.get(Paths.get("model/test-record-object.ts")));
+	}
+
+	@Test
+	public void testGenerateNestedGenericNullable() throws Exception {
+
+		final AnalyzeApi api = new AnalyzeApi();
+		api.addAllApi(List.of(SampleResourceGenericNullableGet.class));
+
+		final Map<java.nio.file.Path, String> generation = TsGenerateApi.generateApi(api);
+
+		for (final java.nio.file.Path elem : generation.keySet()) {
+			LOGGER.info("path= {}", elem);
+		}
+		Assertions.assertEquals("""
+				/**
+				 * Interface of the server (auto-generated code)
+				 */
+				import { z as zod } from "zod";
+				import { ZodInteger } from "./integer";
+
+				export const ZodTestGenericNullableObject = zod.object({
+					listDefault: zod.array(ZodInteger.nullable()).nullable(),
+					listNotNull: zod.array(ZodInteger),
+					mapListDefault: zod.record(zod.string(), zod.array(ZodInteger.nullable()).nullable()).nullable(),
+					mapListNotNullField: zod.record(zod.string(), zod.array(ZodInteger.nullable()).nullable()),
+					mapListAllNotNull: zod.record(zod.string(), zod.array(ZodInteger)),
+
+				});
+
+				export type TestGenericNullableObject = zod.infer<typeof ZodTestGenericNullableObject>;
+
+				export function isTestGenericNullableObject(data: any): data is TestGenericNullableObject {
+					try {
+						ZodTestGenericNullableObject.parse(data);
+						return true;
+					} catch (e: any) {
+						console.log(`Fail to parse data type='ZodTestGenericNullableObject' error=${e}`);
+						return false;
+					}
+				}
+				""", generation.get(Paths.get("model/test-generic-nullable-object.ts")));
+	}
+
+	@Test
+	public void testGenerateDeepGenericNullable() throws Exception {
+
+		final AnalyzeApi api = new AnalyzeApi();
+		api.addAllApi(List.of(SampleResourceGenericNullableDeepGet.class));
+
+		final Map<java.nio.file.Path, String> generation = TsGenerateApi.generateApi(api);
+
+		for (final java.nio.file.Path elem : generation.keySet()) {
+			LOGGER.info("path= {}", elem);
+		}
+		Assertions.assertEquals("""
+				/**
+				 * Interface of the server (auto-generated code)
+				 */
+				import { z as zod } from "zod";
+				import { ZodInteger } from "./integer";
+
+				export const ZodTestGenericNullableDeepObject = zod.object({
+					mapValueNotNull: zod.record(zod.string(), zod.array(ZodInteger.nullable())),
+					mapElementNotNull: zod.record(zod.string(), zod.array(ZodInteger).nullable()),
+					listOfList: zod.array(zod.array(ZodInteger.nullable()).nullable()).nullable(),
+					listOfListElementNotNull: zod.array(zod.array(ZodInteger).nullable()),
+
+				});
+
+				export type TestGenericNullableDeepObject = zod.infer<typeof ZodTestGenericNullableDeepObject>;
+
+				export function isTestGenericNullableDeepObject(data: any): data is TestGenericNullableDeepObject {
+					try {
+						ZodTestGenericNullableDeepObject.parse(data);
+						return true;
+					} catch (e: any) {
+						console.log(`Fail to parse data type='ZodTestGenericNullableDeepObject' error=${e}`);
+						return false;
+					}
+				}
+				""", generation.get(Paths.get("model/test-generic-nullable-deep-object.ts")));
 	}
 }


### PR DESCRIPTION
The Zod generation always emitted generic type arguments (List element, Map value) as non-null, while Java semantics allow null entries. The value is now `.nullable()` by default and can be forced non-null with a type-use `@NotNull` annotation (e.g. `List<@NotNull Integer>`), applied independently at each nesting level. The Map key stays non-null.

Type-use annotations are read by resolving the field/getter `AnnotatedType`; a safe fallback keeps the previous resolution for every non-List/Map case.