### PR TITLE
[FIX] (cron) survive Throwable in tasks and report the failure to the…

### DIFF
--- a/src/main/org/atriasoft/archidata/cron/CronExecutionListener.java
+++ b/src/main/org/atriasoft/archidata/cron/CronExecutionListener.java
@@ -26,4 +26,22 @@ public interface CronExecutionListener {
 	 * @param success {@code true} if the task ran without throwing, {@code false} otherwise
 	 */
 	void onEnd(Object handle, boolean success);
+
+	/**
+	 * Called after a task finished, with the failure cause when it threw. The scheduler catches
+	 * {@link Throwable} around task execution (an {@link Error} such as {@code OutOfMemoryError} in a
+	 * task must never kill the consumer thread), so {@code failure} can be any throwable, not only
+	 * exceptions.
+	 *
+	 * <p>Default implementation delegates to {@link #onEnd(Object, boolean)} so existing listeners
+	 * keep working unchanged; override this variant to record the failure itself (message, stack)
+	 * in the execution journal.
+	 *
+	 * @param handle the handle returned by the matching {@link #onStart}
+	 * @param success {@code true} if the task ran without throwing, {@code false} otherwise
+	 * @param failure what the task threw, or {@code null} on success
+	 */
+	default void onEnd(final Object handle, final boolean success, final Throwable failure) {
+		onEnd(handle, success);
+	}
 }

--- a/src/main/org/atriasoft/archidata/cron/CronScheduler.java
+++ b/src/main/org/atriasoft/archidata/cron/CronScheduler.java
@@ -166,7 +166,9 @@ public class CronScheduler {
 				Thread.currentThread().interrupt();
 			}
 		}
-		LOGGER.debug("Stop CRON producer thread");
+		// WARN for the same reason as the consumer: a silently stopped producer means no
+		// periodic task is ever enqueued again.
+		LOGGER.warn("Stop CRON producer thread");
 	}
 
 	/** Enqueues every one-time scheduled task whose execution time has been reached. */
@@ -219,12 +221,22 @@ public class CronScheduler {
 				Thread.currentThread().interrupt();
 				break;
 			}
-			runTask(pending);
+			try {
+				runTask(pending);
+			} catch (final Throwable ex) {
+				// Belt and braces: runTask already contains everything, but NOTHING may kill
+				// this loop — a dead consumer freezes every periodic task silently (the
+				// producer keeps rejecting re-enqueues of the never-consumed pending tasks).
+				LOGGER.error("CRON consumer survived an unexpected error around task '{}': {}", pending.task().name(),
+						ex.getMessage(), ex);
+			}
 		}
-		LOGGER.debug("Stop CRON consumer thread");
+		// WARN: outside of an explicit stop() this must be visible — a stopped consumer
+		// means no periodic task will ever run again in this process.
+		LOGGER.warn("Stop CRON consumer thread");
 	}
 
-	/** Runs one task: tracks it, notifies the listener around it, and captures the success outcome. */
+	/** Runs one task: tracks it, notifies the listener around it, and captures the outcome. */
 	private void runTask(final PendingTask pending) {
 		final Task task = pending.task();
 		final String name = task.name();
@@ -232,15 +244,19 @@ public class CronScheduler {
 		this.runningTaskNames.add(name);
 		final Object handle = notifyStart(name, pending.trigger());
 		final long start = System.currentTimeMillis();
-		boolean success = true;
+		Throwable failure = null;
 		try {
 			task.action().run();
-		} catch (final Exception ex) {
-			success = false;
+		} catch (final Throwable ex) {
+			// Throwable, not Exception: an Error (OutOfMemoryError during a heavy task, …)
+			// must be recorded as a failure and MUST NOT propagate — it would kill the
+			// consumer loop through the executor's FutureTask without any log, silently
+			// freezing every periodic task while the rest of the process keeps running.
+			failure = ex;
 			LOGGER.error("Fail in CRON consumer throw in task '{}': {}", name, ex.getMessage(), ex);
 		} finally {
 			this.runningTaskNames.remove(name);
-			notifyEnd(handle, success);
+			notifyEnd(handle, failure);
 			final long duration = System.currentTimeMillis() - start;
 			if (duration > 120_000) { // 2 minutes
 				LOGGER.error("Task '{}' executed in {} ms took too long! > 2 minutes", name, duration);
@@ -265,13 +281,13 @@ public class CronScheduler {
 	}
 
 	/** Notifies the listener that a task finished. Never throws. */
-	private void notifyEnd(final Object handle, final boolean success) {
+	private void notifyEnd(final Object handle, final Throwable failure) {
 		final CronExecutionListener listener = this.executionListener;
 		if (listener == null) {
 			return;
 		}
 		try {
-			listener.onEnd(handle, success);
+			listener.onEnd(handle, failure == null, failure);
 		} catch (final Exception ex) {
 			LOGGER.error("CRON execution listener onEnd failed: {}", ex.getMessage(), ex);
 		}

--- a/src/test/test/atriasoft/archidata/cron/TestCronResilience.java
+++ b/src/test/test/atriasoft/archidata/cron/TestCronResilience.java
@@ -1,0 +1,150 @@
+package test.atriasoft.archidata.cron;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.atriasoft.archidata.cron.CronExecutionListener;
+import org.atriasoft.archidata.cron.CronScheduler;
+import org.atriasoft.archidata.cron.CronTriggerType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * The consumer thread must survive ANY throwable from a task — including {@link Error}s. A dead
+ * consumer freezes every periodic task silently: the producer keeps rejecting re-enqueues of the
+ * never-consumed pending tasks while the rest of the process (HTTP, …) looks perfectly healthy.
+ * This exact failure was observed in production with an {@code OutOfMemoryError} thrown by a
+ * backup task: the run was even recorded as SUCCESS because only {@code Exception} was caught.
+ */
+public class TestCronResilience {
+
+	private CronScheduler scheduler;
+
+	@AfterEach
+	public void tearDown() {
+		if (this.scheduler != null) {
+			this.scheduler.stop();
+			this.scheduler = null;
+		}
+	}
+
+	private CronScheduler startedScheduler() {
+		final CronScheduler local = new CronScheduler();
+		local.disableGracePeriodMinutes();
+		local.setEventGraceMillis(50L);
+		this.scheduler = local;
+		return local;
+	}
+
+	/** Listener recording each end notification (success flag + failure). */
+	private record EndRecord(
+			String taskName,
+			boolean success,
+			Throwable failure) {}
+
+	private static class RecordingListener implements CronExecutionListener {
+		final List<EndRecord> ends = new CopyOnWriteArrayList<>();
+
+		@Override
+		public Object onStart(final String taskName, final CronTriggerType trigger) {
+			return taskName;
+		}
+
+		@Override
+		public void onEnd(final Object handle, final boolean success) {
+			throw new IllegalStateException("the scheduler must call the failure-aware variant");
+		}
+
+		@Override
+		public void onEnd(final Object handle, final boolean success, final Throwable failure) {
+			this.ends.add(new EndRecord((String) handle, success, failure));
+		}
+	}
+
+	private static boolean awaitLatch(final CountDownLatch latch, final long timeoutMs) {
+		try {
+			return latch.await(timeoutMs, TimeUnit.MILLISECONDS);
+		} catch (final InterruptedException e) {
+			Thread.currentThread().interrupt();
+			return false;
+		}
+	}
+
+	@Test
+	@Timeout(10)
+	public void consumerSurvivesExceptionAndError() {
+		final CronScheduler local = startedScheduler();
+		final RecordingListener listener = new RecordingListener();
+		local.setExecutionListener(listener);
+		local.start();
+
+		final CountDownLatch survivorRan = new CountDownLatch(1);
+		// Cron expressions that never match during the test: only wake-ups fire them.
+		local.addTask("throws-exception", "0 0 1 1 1", () -> {
+			throw new IllegalStateException("boom exception");
+		});
+		local.addTask("throws-error", "0 0 1 1 1", () -> {
+			throw new OutOfMemoryError("boom error (fabricated, no real allocation failure)");
+		});
+		local.addTask("survivor", "0 0 1 1 1", survivorRan::countDown);
+
+		local.triggerWakeup("throws-exception");
+		local.triggerWakeup("throws-error");
+		local.triggerWakeup("survivor");
+
+		// The survivor runs LAST on the single consumer thread: if it ran, the consumer
+		// survived both the exception and the error.
+		Assertions.assertTrue(awaitLatch(survivorRan, 5_000),
+				"the consumer thread must survive a task throwing an Exception and a task throwing an Error");
+
+		Assertions.assertEquals(3, listener.ends.size());
+		final EndRecord exceptionEnd = listener.ends.get(0);
+		Assertions.assertEquals("throws-exception", exceptionEnd.taskName());
+		Assertions.assertFalse(exceptionEnd.success(), "a throwing task must not be recorded as a success");
+		Assertions.assertInstanceOf(IllegalStateException.class, exceptionEnd.failure());
+
+		final EndRecord errorEnd = listener.ends.get(1);
+		Assertions.assertEquals("throws-error", errorEnd.taskName());
+		Assertions.assertFalse(errorEnd.success(), "an Error-throwing task must not be recorded as a success");
+		Assertions.assertInstanceOf(OutOfMemoryError.class, errorEnd.failure());
+
+		final EndRecord survivorEnd = listener.ends.get(2);
+		Assertions.assertTrue(survivorEnd.success());
+		Assertions.assertNull(survivorEnd.failure());
+	}
+
+	@Test
+	@Timeout(10)
+	public void legacyListenerKeepsWorkingThroughTheDefaultMethod() {
+		final CronScheduler local = startedScheduler();
+		final List<Boolean> ends = new CopyOnWriteArrayList<>();
+		// Legacy shape: only the two-argument onEnd is implemented.
+		local.setExecutionListener(new CronExecutionListener() {
+			@Override
+			public Object onStart(final String taskName, final CronTriggerType trigger) {
+				return null;
+			}
+
+			@Override
+			public void onEnd(final Object handle, final boolean success) {
+				ends.add(success);
+			}
+		});
+		local.start();
+
+		final CountDownLatch ran = new CountDownLatch(1);
+		local.addTask("legacy-fail", "0 0 1 1 1", () -> {
+			throw new OutOfMemoryError("boom");
+		});
+		local.addTask("legacy-ok", "0 0 1 1 1", ran::countDown);
+		local.triggerWakeup("legacy-fail");
+		local.triggerWakeup("legacy-ok");
+
+		Assertions.assertTrue(awaitLatch(ran, 5_000));
+		Assertions.assertEquals(List.of(false, true), ends);
+	}
+}


### PR DESCRIPTION
… listener

A task throwing an Error (observed in production: OutOfMemoryError in a heavy backup task) killed the consumer thread through the executor's FutureTask without any log: every periodic task silently froze while the process kept serving HTTP, and the run was even recorded as a SUCCESS because only Exception was caught around the action.

- runTask catches Throwable, records the run as failed and never lets anything propagate; a belt-and-braces catch in the consumer loop guarantees the loop survives no matter what.
- CronExecutionListener gains onEnd(handle, success, failure) (default delegates to the legacy overload) so execution journals can record what the task actually threw.
- Producer/consumer loop terminations are logged at WARN: outside of an explicit stop() they mean no periodic task will ever run again.